### PR TITLE
Maintaining nth's ability to default if provided index is out of bounds.

### DIFF
--- a/src/traversy/lens.clj
+++ b/src/traversy/lens.clj
@@ -68,8 +68,10 @@
 
 (defn xth
   "A lens from collection -> nth item."
-  [n]
-  (lens (comp list #(nth % n)) (partial fnth n)))
+  ([n]
+   (lens (comp list #(nth % n)) (partial fnth n)))
+  ([n not-found]
+   (lens (comp list #(nth % n not-found)) (partial fnth n))))
 
 (defn ^:no-doc fapply-in [path f x]
   (if (not= (get-in x path ::not-found) ::not-found)

--- a/test/traversy/test/lens.clj
+++ b/test/traversy/test/lens.clj
@@ -91,7 +91,9 @@
 (fact "The 'xth' lens focuses on the nth item of a sequence."
   (-> [2 3 4] (view-single (xth 1))) => 3
   (-> [2 3 4] (view (xth 1))) => [3]
-  (-> [2 3 4] (update (xth 1) inc)) => [2 4 4])
+  (-> [2 3 4] (update (xth 1) inc)) => [2 4 4]
+  (-> [2 3 4] (view-single (xth 4 "not found"))) => "not found"
+  (-> [2 3 4] (view (xth 4 "not found"))) => ["not found"])
 
 (fact "We can 'combine' single-focus lenses."
   (-> {:foo {:bar 9}} (view-single (combine (in [:foo]) (in [:bar])))) => 9


### PR DESCRIPTION
It seems that [nth](http://conj.io/store/v0/org.clojure/clojure/1.7.0-alpha4/clj/clojure.core/nth/) throws an index out of bounds exception if not provided with a 'not-found' value.

Another solution might be to use [get](http://conj.io/store/v0/org.clojure/clojure/1.7.0-alpha4/clj/clojure.core/get) which will return a nil if out of bounds.
