### PR TITLE
Use empty in zero

### DIFF
--- a/src/traversy/lens.cljc
+++ b/src/traversy/lens.cljc
@@ -45,10 +45,7 @@
   (lens (constantly []) fconst))
 
 (defn ^:no-doc zero [x]
-  (cond
-    (map? x) {}
-    (set? x) #{}
-    :otherwise []))
+  (or (empty x) []))
 
 (defn ^:no-doc map-conj [f x] (->> x (map f) (reduce conj (zero x))))
 


### PR DESCRIPTION
Keeps the original collection type during updates.