### PR TITLE
Mark clojure/script as provided dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.5.1
+-----
+* Mark `org.clojure/clojure` and `org.clojure/clojurescript` as provided dependencies so ClojureScript and its own dependencies won't get pulled into pure Clojure projects
+
 0.5.0
 -----
 * 'in' distinguishes between absence of value (empty list returned) and nil value (nil returned)

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject traversy "0.5.0"
+(defproject traversy "0.5.1"
             :description "Multilenses for Clojure."
             :url "https://github.com/ctford/traversy"
             :min-lein-version "2.1.2"
             :license {:name "MIT"
                       :url  "http://opensource.org/licenses/MIT"}
-            :dependencies [[org.clojure/clojure "1.8.0"]
-                           [org.clojure/clojurescript "1.9.229"]]
+            :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
+                           [org.clojure/clojurescript "1.9.229" :scope "provided"]]
             :profiles {:dev {:plugins    [[com.jakemccrary/lein-test-refresh "0.10.0"]
                                           [codox "0.8.10"]
                                           [lein-cljsbuild "1.1.4"]


### PR DESCRIPTION
Not to accidentally pull in clojurescript as a dependency into pure clojure projects.

Proposes a fix to https://github.com/ctford/traversy/issues/15

```sh
> cat deps.edn
{:deps {org.clojure/clojure {:mvn/version "1.8.0"}
        traversy/traversy   {:mvn/version "0.5.1"}}}
```

```sh
> clojure -Stree
org.clojure/clojure 1.8.0
traversy/traversy 0.5.1
```